### PR TITLE
Improve LOD settings and create framework for better lighting

### DIFF
--- a/port/gdx_menu.cpp
+++ b/port/gdx_menu.cpp
@@ -510,6 +510,11 @@ GdxMenu::GdxMenu() : Ship::GuiWindow("gOpenMenuBar", false, "G-Diffuser Menu") {
     CVarRegisterString("gEnhancements.Graphics.PostPipeline", "");
     CVarRegisterInteger("gEnhancements.Graphics.DrawDistance", 100);
     CVarRegisterInteger("gEnhancements.Graphics.ForceMaxMachineLOD", 0);
+    CVarRegisterInteger("gEnhancements.Graphics.MachineLODDistMod", 0);
+    CVarRegisterInteger("gEnhancements.Graphics.ForceDrawMachineShad", 0);
+    CVarRegisterInteger("gEnhancements.Graphics.MachineBoostLODDistMod", 0);
+    CVarRegisterInteger("gEnhancements.Graphics.FancyLighting", 0);
+
     // FramePacing and FrameInterpolation are mutually exclusive pacing owners, both read live.
     // libultraship's Fast3D backend already caps the loop to ~60fps; FramePacing pins it to the N64
     // NTSC rate (~59.94Hz) instead, and wants VSync OFF to avoid beating against the display.

--- a/port/gdx_menu_registry.cpp
+++ b/port/gdx_menu_registry.cpp
@@ -1595,6 +1595,52 @@ void GdxMenu::RegisterMenu() {
                   .ModifiedMarker()
                   .SearchTerms("lod level of detail model quality machines"));
 
+    AddWidget("Enhancements", "Visuals", SECTION_COLUMN_1,
+              WidgetInfo{ .name = "Adjust machine detail", .cVar = "gEnhancements.Graphics.MachineLODDistMod",
+                          .type = GdxUI::WIDGET_CVAR_SLIDER_INT }
+                  .Options(UIWidgets::IntSliderOptions()
+                               .Min(0)
+                               .Max(5)
+                               .DefaultValue(0)
+                               .ShowButtons(false)
+                               .LabelPosition(UIWidgets::LabelPositions::Near)
+                               .Tooltip("Render each machine at a higher-detailed model than default,\n"
+                                        "accounting for distance. 0 = stock distance-based detail."))
+                  .ModifiedMarker()
+                  .SearchTerms("lod level of detail model quality machines"));
+
+    AddWidget("Enhancements", "Visuals", SECTION_COLUMN_1,
+              WidgetInfo{ .name = "Force rendering machine shadows", .cVar = "gEnhancements.Graphics.ForceDrawMachineShad",
+                          .type = GdxUI::WIDGET_CVAR_CHECKBOX }
+                  .Options(UIWidgets::CheckboxOptions().DefaultValue(false).Tooltip(
+                      "Always renders each machine's shadow, ignoring distance.\n"
+                      "Off = stock distance-based shadow rendering."))
+                  .ModifiedMarker()
+                  .SearchTerms("lod level of detail shadow quality machines"));
+
+    AddWidget("Enhancements", "Visuals", SECTION_COLUMN_1,
+              WidgetInfo{ .name = "Adjust machine boosters detail", .cVar = "gEnhancements.Graphics.MachineBoostLODDistMod",
+                          .type = GdxUI::WIDGET_CVAR_SLIDER_INT }
+                  .Options(UIWidgets::IntSliderOptions()
+                               .Min(0)
+                               .Max(2)
+                               .DefaultValue(0)
+                               .ShowButtons(false)
+                               .LabelPosition(UIWidgets::LabelPositions::Near)
+                               .Tooltip("Render each machine's booster graphics at a higher-level than default,\n"
+                                        "accounting for distance. 0 = stock distance-based detail."))
+                  .ModifiedMarker()
+                  .SearchTerms("lod level of detail boosters quality machines"));
+
+    AddWidget("Enhancements", "Visuals", SECTION_COLUMN_1,
+              WidgetInfo{ .name = "Fancy lighting", .cVar = "gEnhancements.Graphics.FancyLighting",
+                          .type = GdxUI::WIDGET_CVAR_CHECKBOX }
+                  .Options(UIWidgets::CheckboxOptions().DefaultValue(false).Tooltip(
+                      "Dims ambient light on each machine so the point light and custom lights\n"
+                      "read better against segment lighting. Off = stock lighting."))
+                  .ModifiedMarker()
+                  .SearchTerms("lighting ambient fog point light machine"));
+
     // Column 2: pacing / interpolation.
     AddWidget("Enhancements", "Visuals", SECTION_COLUMN_2,
               WidgetInfo{ .name = "Enhancements (parity-gated)", .type = GdxUI::WIDGET_SEPARATOR_TEXT });


### PR DESCRIPTION
Editable LOD for machines, boosters, shadows, and preliminary support for better lighting.

Machines LOD setting reduces the LOD value calculated by distance by a set amount 0-5, to 1 minimum.
Setting to 5 (maximum) will set force all machines to max quality for example; setting to 1 will decrease all machines' LOD values by one, minimum result 1, so LOD 1 -> 1, LOD 2 -> 1 .. LOD 6 -> 5.
- Testing on integrated graphics resulted in around a modifier of 2 has the best results.

Force shadows on ignores the shadow distance cutoff.

Boosters have 3 levels of LOD: off, low, high. Similar deal to the machines LOD, where a modifier of 0 will produce stock behavior, 1 will ensure boosters are always shown, 2 will lock boosters to max quality. Oddly enough the code has the reverse LOD scale of boosters compared to machines, this has been mirrored in the code to ensure the UI has a consistent 0 is stock, max is max.

Finally, added in preliminary support for fancy lighting, by reducing the ambient light so new light can shine. This is a larger-scale project than the others; just adding the framework here. Main plans for (faint) light sources are track walls, buildings, gantry bridges (those little things that you pass under), and stronger light sources for the moon in Silence, the lava in Fire Field. Well-placed lighting goes a long way, check out the machine select screen for reference.